### PR TITLE
Add support for students with only 1 parent contact number

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -76,20 +76,28 @@ public class ParserUtil {
         requireNonNull(phones);
         String[] splitPhones = phones.split(",");
 
-        if (splitPhones.length != 2) {
-            throw new ParseException(Phone.INVALID_NUMBER_OF_PHONES);
-        }
-
         Phone[] phoneArray = new Phone[2];
-        for (int i = 0; i < splitPhones.length; i++) {
-            String trimmedPhone = splitPhones[i].trim();
+        if (splitPhones.length == 2) {
+            for (int i = 0; i < splitPhones.length; i++) {
+                String trimmedPhone = splitPhones[i].trim();
+                if (!Phone.isValidPhone(trimmedPhone)) {
+                    throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+                }
+                phoneArray[i] = new Phone(trimmedPhone);
+            }
+            return phoneArray;
+        } else if (splitPhones.length == 1) {
+            String trimmedPhone = splitPhones[0].trim();
             if (!Phone.isValidPhone(trimmedPhone)) {
                 throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
             }
-            phoneArray[i] = new Phone(trimmedPhone);
+            phoneArray[0] = new Phone(trimmedPhone);
+            phoneArray[1] = new Phone(trimmedPhone);
+            return phoneArray;
+        } else {
+            throw new ParseException(Phone.INVALID_NUMBER_OF_PHONES);
         }
 
-        return phoneArray;
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -63,7 +63,8 @@ public class AddCommandParserTest {
         Person singleParent = new PersonBuilder(BOB).withFirstParentPhone("12345678")
                 .withSecondParentPhone("12345678").build();
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + " p/12345678" + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + STUDENT_ID_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, new AddCommand(singleParent));
+                + ADDRESS_DESC_BOB + STUDENT_ID_DESC_BOB + TAG_DESC_FRIEND
+                + TAG_DESC_HUSBAND, new AddCommand(singleParent));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -59,6 +59,11 @@ public class AddCommandParserTest {
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_ADD_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + STUDENT_ID_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
 
+        //with one parent phone
+        Person singleParent = new PersonBuilder(BOB).withFirstParentPhone("12345678")
+                .withSecondParentPhone("12345678").build();
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + " p/12345678" + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + STUDENT_ID_DESC_BOB + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, new AddCommand(singleParent));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)


### PR DESCRIPTION
When input only one phone number, we automatically duplicate it.